### PR TITLE
Add ability to use the name as the end topic name

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/model/Impl/TopicImpl.java
+++ b/src/main/java/com/purbon/kafka/topology/model/Impl/TopicImpl.java
@@ -94,6 +94,7 @@ public class TopicImpl implements Topic, Cloneable {
     this.dataType = dataType;
     this.config = config;
     this.schemas = new ArrayList<>();
+    this.context = new HashMap<>();
     this.replicationFactor = 0;
     this.partitionCount = 0;
     this.appConfig = appConfig;
@@ -133,6 +134,8 @@ public class TopicImpl implements Topic, Cloneable {
     switch (appConfig.getTopicPrefixFormat()) {
       case "default":
         return defaultTopicStructureString(projectPrefix);
+      case "name":
+        return name;
       default:
         return patternBasedTopicNameStructureString();
     }


### PR DESCRIPTION
Whilst it is possible to use a pattern like {{ topic }} when other tooling is being used like ansible there is a collision with {{ }} as it also uses jinja templating.

* **Please check if the PR fulfills these requirements**
- [ ] The commit messages are descriptive
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] An issue has been created for the pull requests. Some issues might require previous discussion.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:


**IMPORTANT**: Please review the CONTRIBUTING.md file for detailed contributing guidelines.
**IMPORTANT**: Your pull request MUST target `master`.

PLEASE REMOVE THIS TEMPLATE BEFORE SUBMITTING